### PR TITLE
removing a line so that the polygon fills appropriately

### DIFF
--- a/src/objects/polygon.cpp
+++ b/src/objects/polygon.cpp
@@ -13,9 +13,9 @@ void polygon::draw(cairo_t *ctx) const {
 
     for (const auto& point : points) {
         cairo_line_to(ctx, point.x - center.x, point.y - center.y);
-        cairo_move_to(ctx, point.x - center.x, point.y - center.y);
     }
 
+    cairo_close_path(ctx);
     if (fill) {
         cairo_fill(ctx);
     }


### PR DESCRIPTION
For some reason, the polygon object did not fill correctly with the `cairo_move_to(ctx, point.x - center.x, point.y - center.y)` command there. I am sending a PR instead of just merging it because I think this might screw up something about the polygon drawing elsewhere on accident, but I am not sure.

I agree to have all of my commits to this repository licensed under the MIT license, as found in LICENSE.md.
